### PR TITLE
feat: 🎸 js_compressor を terser に変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ group :test, :development, :production do
   gem 'jbuilder'
   gem 'jquery-rails'
   gem 'sass-rails'
+  gem 'terser'
   gem 'turbolinks'
-  gem 'uglifier'
 
   gem 'bootstrap'
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,6 +435,8 @@ GEM
     sshkit-interactive (0.3.0)
       sshkit (~> 1.12)
     temple (0.8.2)
+    terser (1.1.12)
+      execjs (>= 0.3.0, < 3)
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.11)
@@ -457,8 +459,6 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -521,9 +521,9 @@ DEPENDENCIES
   smarter_csv
   spring
   spring-watcher-listen
+  terser
   turbolinks
   twitter
-  uglifier
   unicorn
   web-console
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :terser
   config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
- fix: 🐛 Docker の Ruby のイメージのバージョンタグをホストマシンと同等にした
- feat: 🎸 js_compressor を terser に変更
