### PR TITLE
ci: 🎡 ISSUE_TEMPLATE は役割を終えたので削除した

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_normal.md
+++ b/.github/ISSUE_TEMPLATE/issue_normal.md
@@ -1,8 +1,0 @@
----
-name: Normal issue
-about: about
-title: ''
-labels:
-assignees: ''
----
-# Issue


### PR DESCRIPTION
This pull request includes a small change to the `.github/ISSUE_TEMPLATE/issue_normal.md` file. The change removes the template content for normal issues, including the name, about, title, labels, assignees, and the issue section.