### PR TITLE
feat: 🎸 Unicorn は役割を終えたので削除した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,11 +24,11 @@ group :test, :development, :production do
   gem 'pg'
   gem 'pry'
   gem 'pry-rails'
+  gem 'puma'
   gem 'rb-readline'
   gem 'slim-rails'
   gem 'smarter_csv'
   gem 'twitter'
-  gem 'unicorn'
 end
 
 group :development, :test do
@@ -56,6 +56,5 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'puma'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kgio (2.11.4)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -339,7 +338,6 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    raindrops (0.20.1)
     rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -470,9 +468,6 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
-    unicorn (6.1.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
     uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
@@ -533,7 +528,6 @@ DEPENDENCIES
   terser
   turbolinks
   twitter
-  unicorn
   web-console
 
 RUBY VERSION

--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -1,9 +1,0 @@
-listen 8081
-worker_processes 2
-timeout 30
-
-preload_app true
-
-pid 'tmp/pids/unicorn.pid'
-stdout_path 'log/unicorn_stdout.log'
-stderr_path 'log/unicorn_stderr.log'

--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -1,9 +1,0 @@
-listen 8080
-worker_processes 2
-timeout 30
-
-preload_app true
-
-pid 'tmp/pids/unicorn.pid'
-stdout_path 'log/unicorn_stdout.log'
-stderr_path 'log/unicorn_stderr.log'


### PR DESCRIPTION
This pull request includes changes to the `Gemfile` and the removal of configuration files for Unicorn. The main goal is to replace Unicorn with Puma as the web server for the application. 

Key changes include:

### Gemfile adjustments:
* Added `puma` gem to the `:test, :development, :production` group.
* Removed `unicorn` gem from the `:test, :development, :production` group.
* Removed `puma` gem from the `:test` group.

### Configuration cleanup:
* Removed `config/unicorn/development.rb` configuration file.
* Removed `config/unicorn/production.rb` configuration file.