### PR TITLE
ci: 🎡 build_docker_image ワークフロー の内容を最新のものにアップデートした

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -8,6 +8,14 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
 env:
   # TODO: Git のタグを取得して、イメージのタグにする
   DOCKER_IMAGE: asia-northeast1-docker.pkg.dev/${{ secrets.CLOUD_RUN_PROJECT }}/cloud-run-source-deploy/gensosenkyo-2018
@@ -16,11 +24,15 @@ env:
   PG_PORT_TEST: 5432
   PG_USERNAME_TEST: postgres_user
   PG_PASSWORD_TEST: postgres_password
+  LANG: ja_JP.UTF-8
+  RUBY_YJIT_ENABLE: 1
+  TZ: Asia/Tokyo
 
 jobs:
   build_docker_image:
     name: Docker イメージ をビルドできるかどうか
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:15.4
@@ -35,8 +47,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - name: ソースコードをチェックアウトする
-        uses: actions/checkout@v3
+      - name: $ git clone する
+        # https://github.com/actions/checkout/releases
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Docker イメージ をビルドする
         env:
           DOCKER_BUILDKIT: 1 # '# syntax = docker/dockerfile:1.2' は不要だが、この指定は 2023/01/23 現在、必須


### PR DESCRIPTION
This pull request includes several updates to the `.github/workflows/build_docker_image.yml` file to enhance the workflow configuration and improve the build process. The most important changes include adding concurrency controls, updating environment variables, and modifying job steps.

Workflow configuration improvements:

* Added `concurrency` settings to group workflows and cancel in-progress runs for the same group. (`[.github/workflows/build_docker_image.ymlR11-R18](diffhunk://#diff-cf9e37f38163766aa65e6d1700f69a4e5ba1792bee8378ed5dd63d883df42243R11-R18)`)
* Set default shell to `bash` for all run steps. (`[.github/workflows/build_docker_image.ymlR11-R18](diffhunk://#diff-cf9e37f38163766aa65e6d1700f69a4e5ba1792bee8378ed5dd63d883df42243R11-R18)`)

Environment variable updates:

* Added `LANG`, `RUBY_YJIT_ENABLE`, and `TZ` environment variables. (`[.github/workflows/build_docker_image.ymlR27-R35](diffhunk://#diff-cf9e37f38163766aa65e6d1700f69a4e5ba1792bee8378ed5dd63d883df42243R27-R35)`)
* Updated the runner to use `ubuntu-24.04` and set a timeout of 15 minutes for the job. (`[.github/workflows/build_docker_image.ymlR27-R35](diffhunk://#diff-cf9e37f38163766aa65e6d1700f69a4e5ba1792bee8378ed5dd63d883df42243R27-R35)`)

Job step modifications:

* Changed the checkout action to use a specific commit hash for version `v4.2.2` and disabled credential persistence. (`[.github/workflows/build_docker_image.ymlL38-R54](diffhunk://#diff-cf9e37f38163766aa65e6d1700f69a4e5ba1792bee8378ed5dd63d883df42243L38-R54)`)